### PR TITLE
[ADD] Aho-Corasick 多模式匹配

### DIFF
--- a/src/include/str/AhoCorasick.h
+++ b/src/include/str/AhoCorasick.h
@@ -1,0 +1,204 @@
+#ifndef __DSA_AHO_CORASICK
+#define __DSA_AHO_CORASICK
+
+#include <cstddef>
+#include <cstring>
+#include <vector>
+
+#include "AhoCorasickImpl.h"
+#include "Vector.h"
+#include "dsa_string.h"
+
+/*
+ * 工程门面层：
+ * - 管理业务 pattern ID、构建状态和结果对象；
+ * - 将仓库 String / Vector 接口适配到独立算法核心；
+ * - Build 完成后查询只读，可被多个调用方并发复用。
+ */
+class AhoCorasick {
+public:
+    struct Pattern {
+        int id;
+        String text;
+
+        Pattern() : id(-1), text() {}
+        Pattern(int pattern_id, const String& pattern_text)
+            : id(pattern_id), text(pattern_text) {}
+    };
+
+    struct Match {
+        int pattern_id;
+        Rank pattern_index;
+        size_type start;
+        size_type end;
+
+        Match()
+            : pattern_id(-1), pattern_index(-1), start(0), end(0) {}
+
+        Match(int id, Rank index, size_type match_start, size_type match_end)
+            : pattern_id(id),
+              pattern_index(index),
+              start(match_start),
+              end(match_end) {}
+    };
+
+private:
+    Vector<Pattern> patterns_;
+    ac_algorithm::AhoCorasickImpl algorithm_;
+    bool built_;
+    int next_pattern_id_;
+
+    bool idExists(int pattern_id) const {
+        for (Rank i = 0; i < patterns_.size(); ++i) {
+            if (patterns_[i].id == pattern_id) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    Match adapt(const ac_algorithm::AhoCorasickIndexMatch& match) const {
+        const Rank index = static_cast<Rank>(match.pattern_index);
+        return Match(patterns_[index].id,
+                     index,
+                     static_cast<size_type>(match.start),
+                     static_cast<size_type>(match.end));
+    }
+
+public:
+    AhoCorasick() : built_(false), next_pattern_id_(0) {}
+
+    int add(const String& pattern) {
+        if (pattern.empty()) {
+            return -1;
+        }
+
+        while (idExists(next_pattern_id_)) {
+            ++next_pattern_id_;
+        }
+
+        const int pattern_id = next_pattern_id_++;
+        patterns_.insert(Pattern(pattern_id, pattern));
+        built_ = false;
+        return pattern_id;
+    }
+
+    int add(const char* pattern) {
+        if (pattern == nullptr) {
+            return -1;
+        }
+        return add(String(pattern));
+    }
+
+    bool add(const String& pattern, int pattern_id) {
+        if (pattern.empty() || idExists(pattern_id)) {
+            return false;
+        }
+
+        patterns_.insert(Pattern(pattern_id, pattern));
+        if (pattern_id >= next_pattern_id_) {
+            next_pattern_id_ = pattern_id + 1;
+        }
+        built_ = false;
+        return true;
+    }
+
+    bool add(const char* pattern, int pattern_id) {
+        if (pattern == nullptr) {
+            return false;
+        }
+        return add(String(pattern), pattern_id);
+    }
+
+    void build() {
+        algorithm_.clear();
+        for (Rank i = 0; i < patterns_.size(); ++i) {
+            const Pattern& pattern = patterns_[i];
+            algorithm_.addPattern(pattern.text.c_str(), pattern.text.size());
+        }
+        algorithm_.build();
+        built_ = true;
+    }
+
+    void clear() {
+        while (!patterns_.empty()) {
+            patterns_.remove(patterns_.size() - 1);
+        }
+        algorithm_.clear();
+        built_ = false;
+        next_pattern_id_ = 0;
+    }
+
+    bool isBuilt() const {
+        return built_;
+    }
+
+    Rank patternCount() const {
+        return patterns_.size();
+    }
+
+    const Pattern* pattern(Rank index) const {
+        if (index < 0 || index >= patterns_.size()) {
+            return nullptr;
+        }
+        return &patterns_[index];
+    }
+
+    const Pattern* patternById(int pattern_id) const {
+        for (Rank i = 0; i < patterns_.size(); ++i) {
+            if (patterns_[i].id == pattern_id) {
+                return &patterns_[i];
+            }
+        }
+        return nullptr;
+    }
+
+    bool contains(const String& text) const {
+        return built_ && algorithm_.contains(text.c_str(), text.size());
+    }
+
+    bool contains(const char* text) const {
+        return text != nullptr && contains(String(text));
+    }
+
+    bool findFirst(const String& text, Match& result) const {
+        if (!built_) {
+            return false;
+        }
+
+        ac_algorithm::AhoCorasickIndexMatch raw_match;
+        if (!algorithm_.findFirst(text.c_str(), text.size(), raw_match)) {
+            return false;
+        }
+
+        result = adapt(raw_match);
+        return true;
+    }
+
+    bool findFirst(const char* text, Match& result) const {
+        return text != nullptr && findFirst(String(text), result);
+    }
+
+    Vector<Match> findAll(const String& text) const {
+        Vector<Match> matches;
+        if (!built_) {
+            return matches;
+        }
+
+        const std::vector<ac_algorithm::AhoCorasickIndexMatch> raw_matches =
+            algorithm_.findAll(text.c_str(), text.size());
+        for (std::size_t i = 0; i < raw_matches.size(); ++i) {
+            matches.insert(adapt(raw_matches[i]));
+        }
+        return matches;
+    }
+
+    Vector<Match> findAll(const char* text) const {
+        if (text == nullptr) {
+            return Vector<Match>();
+        }
+        return findAll(String(text));
+    }
+};
+
+#endif

--- a/src/include/str/AhoCorasickImpl.h
+++ b/src/include/str/AhoCorasickImpl.h
@@ -1,0 +1,201 @@
+#ifndef __DSA_AHO_CORASICK_IMPL
+#define __DSA_AHO_CORASICK_IMPL
+
+#include <array>
+#include <cstddef>
+#include <queue>
+#include <vector>
+
+namespace ac_algorithm {
+
+struct AhoCorasickIndexMatch {
+    std::size_t pattern_index;
+    std::size_t start;
+    std::size_t end;
+
+    AhoCorasickIndexMatch()
+        : pattern_index(0), start(0), end(0) {}
+
+    AhoCorasickIndexMatch(std::size_t index,
+                          std::size_t match_start,
+                          std::size_t match_end)
+        : pattern_index(index), start(match_start), end(match_end) {}
+};
+
+/*
+ * 教学算法层：
+ * - 只处理字节序列、模式下标和 failure 转移；
+ * - 不关心业务 ID、分类、生命周期或返回对象包装；
+ * - 使用 256 路字节字母表，因此可匹配 UTF-8 文本，但位置是字节偏移。
+ */
+class AhoCorasickImpl {
+private:
+    static const std::size_t AlphabetSize = 256;
+
+    struct Node {
+        std::array<std::size_t, AlphabetSize> next;
+        std::size_t fail;
+        std::vector<std::size_t> outputs;
+
+        Node() : fail(0) {
+            next.fill(invalidState());
+        }
+
+        static std::size_t invalidState() {
+            return static_cast<std::size_t>(-1);
+        }
+    };
+
+    std::vector<Node> nodes_;
+    std::vector<std::size_t> pattern_lengths_;
+    bool built_;
+
+    static std::size_t invalidState() {
+        return static_cast<std::size_t>(-1);
+    }
+
+    static std::size_t symbol(char value) {
+        return static_cast<unsigned char>(value);
+    }
+
+    static void appendOutputs(Node& target, const Node& fallback) {
+        target.outputs.insert(target.outputs.end(),
+                              fallback.outputs.begin(),
+                              fallback.outputs.end());
+    }
+
+public:
+    AhoCorasickImpl() : built_(false) {
+        nodes_.push_back(Node());
+    }
+
+    void clear() {
+        nodes_.clear();
+        nodes_.push_back(Node());
+        pattern_lengths_.clear();
+        built_ = false;
+    }
+
+    std::size_t addPattern(const char* pattern, std::size_t length) {
+        if (built_ || pattern == nullptr || length == 0) {
+            return invalidState();
+        }
+
+        std::size_t state = 0;
+        for (std::size_t i = 0; i < length; ++i) {
+            const std::size_t c = symbol(pattern[i]);
+            std::size_t next_state = nodes_[state].next[c];
+            if (next_state == invalidState()) {
+                next_state = nodes_.size();
+                nodes_[state].next[c] = next_state;
+                nodes_.push_back(Node());
+            }
+            state = next_state;
+        }
+
+        const std::size_t pattern_index = pattern_lengths_.size();
+        pattern_lengths_.push_back(length);
+        nodes_[state].outputs.push_back(pattern_index);
+        return pattern_index;
+    }
+
+    void build() {
+        if (built_) {
+            return;
+        }
+
+        std::queue<std::size_t> pending;
+        for (std::size_t c = 0; c < AlphabetSize; ++c) {
+            const std::size_t child = nodes_[0].next[c];
+            if (child == invalidState()) {
+                nodes_[0].next[c] = 0;
+            } else {
+                nodes_[child].fail = 0;
+                pending.push(child);
+            }
+        }
+
+        while (!pending.empty()) {
+            const std::size_t state = pending.front();
+            pending.pop();
+
+            for (std::size_t c = 0; c < AlphabetSize; ++c) {
+                const std::size_t child = nodes_[state].next[c];
+                if (child == invalidState()) {
+                    nodes_[state].next[c] = nodes_[nodes_[state].fail].next[c];
+                    continue;
+                }
+
+                const std::size_t fallback = nodes_[nodes_[state].fail].next[c];
+                nodes_[child].fail = fallback;
+                appendOutputs(nodes_[child], nodes_[fallback]);
+                pending.push(child);
+            }
+        }
+
+        built_ = true;
+    }
+
+    bool built() const {
+        return built_;
+    }
+
+    std::size_t patternCount() const {
+        return pattern_lengths_.size();
+    }
+
+    bool contains(const char* text, std::size_t length) const {
+        AhoCorasickIndexMatch ignored;
+        return findFirst(text, length, ignored);
+    }
+
+    bool findFirst(const char* text,
+                   std::size_t length,
+                   AhoCorasickIndexMatch& result) const {
+        if (!built_ || text == nullptr) {
+            return false;
+        }
+
+        std::size_t state = 0;
+        for (std::size_t i = 0; i < length; ++i) {
+            state = nodes_[state].next[symbol(text[i])];
+            if (!nodes_[state].outputs.empty()) {
+                const std::size_t pattern_index = nodes_[state].outputs.front();
+                const std::size_t end = i + 1;
+                result = AhoCorasickIndexMatch(
+                    pattern_index,
+                    end - pattern_lengths_[pattern_index],
+                    end);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    std::vector<AhoCorasickIndexMatch> findAll(const char* text,
+                                                std::size_t length) const {
+        std::vector<AhoCorasickIndexMatch> matches;
+        if (!built_ || text == nullptr) {
+            return matches;
+        }
+
+        std::size_t state = 0;
+        for (std::size_t i = 0; i < length; ++i) {
+            state = nodes_[state].next[symbol(text[i])];
+            const std::vector<std::size_t>& outputs = nodes_[state].outputs;
+            for (std::size_t j = 0; j < outputs.size(); ++j) {
+                const std::size_t pattern_index = outputs[j];
+                const std::size_t end = i + 1;
+                matches.push_back(AhoCorasickIndexMatch(
+                    pattern_index,
+                    end - pattern_lengths_[pattern_index],
+                    end));
+            }
+        }
+        return matches;
+    }
+};
+
+} // namespace ac_algorithm
+
+#endif

--- a/test/test_aho_corasick.cpp
+++ b/test/test_aho_corasick.cpp
@@ -1,0 +1,164 @@
+#include <gtest/gtest.h>
+
+#include <cstring>
+#include <vector>
+
+#include "AhoCorasick.h"
+#include "AhoCorasickImpl.h"
+
+TEST(AhoCorasickAlgorithmTest, CoreWorksWithoutBusinessFacade) {
+    ac_algorithm::AhoCorasickImpl algorithm;
+    EXPECT_EQ(algorithm.addPattern("he", 2), 0u);
+    EXPECT_EQ(algorithm.addPattern("she", 3), 1u);
+    EXPECT_EQ(algorithm.addPattern("hers", 4), 2u);
+
+    algorithm.build();
+
+    const std::vector<ac_algorithm::AhoCorasickIndexMatch> matches =
+        algorithm.findAll("ushers", 6);
+    ASSERT_EQ(matches.size(), 3u);
+    EXPECT_EQ(matches[0].pattern_index, 1u);
+    EXPECT_EQ(matches[0].start, 1u);
+    EXPECT_EQ(matches[0].end, 4u);
+    EXPECT_EQ(matches[1].pattern_index, 0u);
+    EXPECT_EQ(matches[1].start, 2u);
+    EXPECT_EQ(matches[1].end, 4u);
+    EXPECT_EQ(matches[2].pattern_index, 2u);
+    EXPECT_EQ(matches[2].start, 2u);
+    EXPECT_EQ(matches[2].end, 6u);
+}
+
+TEST(AhoCorasickTest, FindsAllStandardPatterns) {
+    AhoCorasick matcher;
+    EXPECT_TRUE(matcher.add("he", 10));
+    EXPECT_TRUE(matcher.add("she", 20));
+    EXPECT_TRUE(matcher.add("his", 30));
+    EXPECT_TRUE(matcher.add("hers", 40));
+    matcher.build();
+
+    const Vector<AhoCorasick::Match> matches = matcher.findAll("ushers");
+    ASSERT_EQ(matches.size(), 3);
+
+    EXPECT_EQ(matches[0].pattern_id, 20);
+    EXPECT_EQ(matches[0].start, 1u);
+    EXPECT_EQ(matches[0].end, 4u);
+
+    EXPECT_EQ(matches[1].pattern_id, 10);
+    EXPECT_EQ(matches[1].start, 2u);
+    EXPECT_EQ(matches[1].end, 4u);
+
+    EXPECT_EQ(matches[2].pattern_id, 40);
+    EXPECT_EQ(matches[2].start, 2u);
+    EXPECT_EQ(matches[2].end, 6u);
+}
+
+TEST(AhoCorasickTest, RequiresBuildAndFindsFirst) {
+    AhoCorasick matcher;
+    matcher.add("error", 7);
+
+    AhoCorasick::Match match;
+    EXPECT_FALSE(matcher.contains("fatal error"));
+    EXPECT_FALSE(matcher.findFirst("fatal error", match));
+
+    matcher.build();
+    EXPECT_TRUE(matcher.isBuilt());
+    EXPECT_TRUE(matcher.contains("fatal error"));
+    ASSERT_TRUE(matcher.findFirst("fatal error", match));
+    EXPECT_EQ(match.pattern_id, 7);
+    EXPECT_EQ(match.start, 6u);
+    EXPECT_EQ(match.end, 11u);
+}
+
+TEST(AhoCorasickTest, AddingAfterBuildInvalidatesMatcher) {
+    AhoCorasick matcher;
+    matcher.add("alpha", 1);
+    matcher.build();
+    EXPECT_TRUE(matcher.contains("alpha"));
+
+    EXPECT_TRUE(matcher.add("beta", 2));
+    EXPECT_FALSE(matcher.isBuilt());
+    EXPECT_FALSE(matcher.contains("alpha beta"));
+
+    matcher.build();
+    EXPECT_TRUE(matcher.contains("alpha beta"));
+    EXPECT_EQ(matcher.findAll("alpha beta").size(), 2);
+}
+
+TEST(AhoCorasickTest, ValidatesPatternsAndBusinessIds) {
+    AhoCorasick matcher;
+    EXPECT_EQ(matcher.add(""), -1);
+    EXPECT_EQ(matcher.add(static_cast<const char*>(nullptr)), -1);
+    EXPECT_TRUE(matcher.add("same", 100));
+    EXPECT_FALSE(matcher.add("other", 100));
+    EXPECT_FALSE(matcher.add("", 101));
+
+    const int generated_id = matcher.add("generated");
+    EXPECT_EQ(generated_id, 101);
+    EXPECT_EQ(matcher.patternCount(), 2);
+
+    const AhoCorasick::Pattern* by_id = matcher.patternById(100);
+    ASSERT_NE(by_id, nullptr);
+    EXPECT_STREQ(by_id->text.c_str(), "same");
+    EXPECT_EQ(matcher.pattern(-1), nullptr);
+    EXPECT_EQ(matcher.pattern(2), nullptr);
+}
+
+TEST(AhoCorasickTest, AllowsSameTextWithDifferentBusinessIds) {
+    AhoCorasick matcher;
+    EXPECT_TRUE(matcher.add("duplicate", 1));
+    EXPECT_TRUE(matcher.add("duplicate", 2));
+    matcher.build();
+
+    const Vector<AhoCorasick::Match> matches = matcher.findAll("duplicate");
+    ASSERT_EQ(matches.size(), 2);
+    EXPECT_EQ(matches[0].pattern_id, 1);
+    EXPECT_EQ(matches[1].pattern_id, 2);
+}
+
+TEST(AhoCorasickTest, HandlesOverlappingPatterns) {
+    AhoCorasick matcher;
+    matcher.add("a", 1);
+    matcher.add("aa", 2);
+    matcher.add("aaa", 3);
+    matcher.build();
+
+    const Vector<AhoCorasick::Match> matches = matcher.findAll("aaaa");
+    EXPECT_EQ(matches.size(), 9);
+}
+
+TEST(AhoCorasickTest, SupportsUtf8AsByteSequence) {
+    AhoCorasick matcher;
+    matcher.add("身份证", 1);
+    matcher.add("银行卡", 2);
+    matcher.build();
+
+    const String text("请提供身份证和银行卡信息");
+    const Vector<AhoCorasick::Match> matches = matcher.findAll(text);
+    ASSERT_EQ(matches.size(), 2);
+
+    for (Rank i = 0; i < matches.size(); ++i) {
+        const AhoCorasick::Match& match = matches[i];
+        const String matched(text.c_str() + match.start, match.end - match.start);
+        const AhoCorasick::Pattern* pattern = matcher.pattern(match.pattern_index);
+        ASSERT_NE(pattern, nullptr);
+        EXPECT_EQ(std::strcmp(matched.c_str(), pattern->text.c_str()), 0);
+    }
+}
+
+TEST(AhoCorasickTest, ClearResetsReusableMatcher) {
+    AhoCorasick matcher;
+    matcher.add("old", 9);
+    matcher.build();
+    EXPECT_TRUE(matcher.contains("old"));
+
+    matcher.clear();
+    EXPECT_FALSE(matcher.isBuilt());
+    EXPECT_EQ(matcher.patternCount(), 0);
+    EXPECT_EQ(matcher.patternById(9), nullptr);
+
+    EXPECT_EQ(matcher.add("new"), 0);
+    matcher.build();
+    EXPECT_TRUE(matcher.contains("new"));
+    EXPECT_FALSE(matcher.contains(static_cast<const char*>(nullptr)));
+    EXPECT_EQ(matcher.findAll(static_cast<const char*>(nullptr)).size(), 0);
+}


### PR DESCRIPTION
## 变更

- 新增 `AhoCorasickImpl.h`：独立的教学算法核心，只处理 Trie、failure 指针、输出继承和字节序列扫描。
- 新增 `AhoCorasick.h`：工程门面，管理业务 pattern ID、显式 Build 生命周期、`contains` / `findFirst` / `findAll` 与结果适配。
- 新增单元测试，覆盖标准示例、failure 回退、重叠模式、重复文本、重新构建、清空复用及 UTF-8 字节匹配。

## 设计边界

- 类似 `RedBlack` 被 `HashMap` 组合使用：算法结构不感知上层业务语义。
- 类似 `Sort.h` / `SortImpl.h`：公开门面与教学实现分文件隔离。
- 匹配位置采用 UTF-8 字节偏移，区间为 `[start, end)`。

## 验证

已通过：

- Linux GCC C++11 / C++14 / C++20
- Linux Clang C++11 / C++14
- macOS GCC C++14 / C++17
- macOS Clang C++17

以上任务均完成 Build、测试与 coverage。

Windows 矩阵在 CMake 配置阶段失败，未进入本 PR 代码编译：当前 `windows-latest` 已切到 VS 2026 runner，但工作流仍固定使用 `Visual Studio 17 2022` generator，属于现有 CI 配置问题。